### PR TITLE
Show "Average Variance" instead of "Shares/Diff"

### DIFF
--- a/www/app/templates/luck.hbs
+++ b/www/app/templates/luck.hbs
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th>Blocks</th>
-      <th>Shares/Diff</th>
+      <th>Average Variance</th>
       <th>Uncle Rate</th>
       <th>Orphan Rate</th>
     </tr>


### PR DESCRIPTION
To make the the view more human friendly can we rename the Shares/Diff column to Average Variance?